### PR TITLE
Use valid license string like other YaST modules

### DIFF
--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -38,7 +38,7 @@ BuildRequires:  rubygem(yast-rake)
 BuildRequires:  rubygem(rspec)
 
 Summary:        YaST2 - Module to configure RMT
-License:        GPL-2.0 or GPL-3.0
+License:        GPL-2.0-only
 Group:          System/YaST
 Url:            https://github.com/yast/yast-rmt
 


### PR DESCRIPTION
SRs to Factory got rejected because of an invalid license string.