### PR TITLE
Allow user to skip registration

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Dec 20 21:49:28 UTC 2018 - vzepedamas@suse.com
+
+- Allow user to skip registration (bsc#1119386)
+
+-------------------------------------------------------------------
 Mon Oct 29 12:57:32 UTC 2018 - thutterer@suse.com
 
 - version 1.1.1

--- a/spec/rmt/wizard_maria_db_page_spec.rb
+++ b/spec/rmt/wizard_maria_db_page_spec.rb
@@ -39,6 +39,7 @@ describe RMT::WizardMariaDBPage do
   describe '#render_content' do
     it 'renders UI elements' do
       expect(Yast::Wizard).to receive(:SetNextButton).with(:next, Yast::Label.NextButton)
+      expect(Yast::Wizard).to receive(:HideBackButton)
       expect(Yast::Wizard).to receive(:SetContents)
 
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:db_username), :Value, config['database']['username'])

--- a/spec/rmt/wizard_scc_page_spec.rb
+++ b/spec/rmt/wizard_scc_page_spec.rb
@@ -29,6 +29,7 @@ describe RMT::WizardSCCPage do
     it 'renders UI elements' do
       expect(Yast::Wizard).to receive(:SetAbortButton).with(:abort, Yast::Label.CancelButton)
       expect(Yast::Wizard).to receive(:SetNextButton).with(:next, Yast::Label.NextButton)
+      expect(Yast::Wizard).to receive(:SetBackButton).with(:skip, Yast::Label.SkipButton)
       expect(Yast::Wizard).to receive(:SetContents)
 
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:scc_username), :Value, config['scc']['username'])
@@ -42,6 +43,24 @@ describe RMT::WizardSCCPage do
     it 'finishes when cancel button is clicked' do
       expect(scc_page).to receive(:finish_dialog).with(:abort)
       scc_page.abort_handler
+    end
+  end
+
+  describe '#skip_handler' do
+    context 'when cancel is clicked' do
+      it 'stays on the same page' do
+        expect(Yast::Popup).to receive(:AnyQuestion).and_return(false)
+        expect(scc_page).not_to receive(:finish_dialog)
+        scc_page.next_handler
+      end
+    end
+
+    context 'when ignore continue is clicked' do
+      it 'stays on the same page' do
+        expect(Yast::Popup).to receive(:AnyQuestion).and_return(true)
+        expect(scc_page).to receive(:finish_dialog).with(:next)
+        scc_page.next_handler
+      end
     end
   end
 

--- a/src/lib/rmt/wizard_maria_db_page.rb
+++ b/src/lib/rmt/wizard_maria_db_page.rb
@@ -59,6 +59,7 @@ class RMT::WizardMariaDBPage < Yast::Client
     )
 
     Wizard.SetNextButton(:next, Label.NextButton)
+    Wizard.HideBackButton()
     Wizard.SetContents(
       _('RMT Configuration - Step 2/5'),
       contents,

--- a/src/lib/rmt/wizard_scc_page.rb
+++ b/src/lib/rmt/wizard_scc_page.rb
@@ -34,6 +34,8 @@ class RMT::WizardSCCPage < Yast::Client
   def render_content
     Wizard.SetAbortButton(:abort, Label.CancelButton)
     Wizard.SetNextButton(:next, Label.NextButton)
+    Wizard.SetBackButton(:skip, Label.SkipButton)
+
 
     contents = Frame(
       _('Organization Credentials'),
@@ -51,7 +53,7 @@ class RMT::WizardSCCPage < Yast::Client
         ),
         HSpacing(1)
       )
-    )
+)
 
     Wizard.SetContents(
       _('RMT Configuration - Step 1/5'),
@@ -67,6 +69,22 @@ class RMT::WizardSCCPage < Yast::Client
 
   def abort_handler
     finish_dialog(:abort)
+  end
+
+  def skip_handler
+    @config['scc']['username'] = UI.QueryWidget(Id(:scc_username), :Value)
+    @config['scc']['password'] = UI.QueryWidget(Id(:scc_password), :Value)
+
+    return unless Popup.AnyQuestion(
+      _('Skip SCC registration?'),
+      _("This is only recommended for air-gapped environments.\nRMT will not be able to sync and mirror data.\n\nDo you want to continue?"),
+      _('Ignore and continue'),
+      _('Go back'),
+      :focus_no
+    )
+
+    RMT::Utils.write_config_file(@config)
+    finish_dialog(:next)
   end
 
   def next_handler


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

Added an option to skip SCC configuration, meant for air-gapped environments.