### PR TITLE
Remove broken hyperlink

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jan 14 13:42:04 UTC 2019 - thutterer@suse.com
+
+- Remove broken hyperlink from help (bsc#1120672)
+
+-------------------------------------------------------------------
 Fri Jan  4 09:46:24 UTC 2019 - hschmidt@suse.com
 
 - Release version 1.2.0

--- a/src/lib/rmt/wizard_scc_page.rb
+++ b/src/lib/rmt/wizard_scc_page.rb
@@ -58,7 +58,7 @@ class RMT::WizardSCCPage < Yast::Client
     Wizard.SetContents(
       _('RMT Configuration - Step 1/5'),
       contents,
-      _("<p>Organization credentials can be found on the Organization page at <a href='https://scc.suse.com/'>SUSE Customer Center</a>.</p>"),
+      _('<p>Organization credentials can be found on the Organization page in the SUSE Customer Center.</p><p>https://scc.suse.com</p>'),
       true,
       true
     )


### PR DESCRIPTION
Hyperlinks are intended e.g. for navigation in hypertext aware help document. However, yast is not able to open external pages nor will it open a web browser for external links.