### PR TITLE
Launch as root from gnome-shell menu

### DIFF
--- a/src/desktop/rmt.desktop
+++ b/src/desktop/rmt.desktop
@@ -9,7 +9,7 @@ X-SuSE-YaST-AutoInst=
 X-SuSE-YaST-AutoInstResource=rmt
 
 Icon=yast-rmt
-Exec=/sbin/yast2 rmt
+Exec=xdg-su -c "/sbin/yast2 rmt"
 
 Name=RMT Configuration
 GenericName=RMT Configuration


### PR DESCRIPTION
Fixes https://bugzilla.suse.com/show_bug.cgi?id=1123562 - yast2-rmt : no password asked when launching from gnome-shell directly