### PR TITLE
Use %{} in translatable strings (bsc#1171555)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,8 @@ RSpec/MultipleExpectations:
 
 RSpec/SubjectStub:
   Enabled: false
+
+# disabled, %<> should not be used in translatable strings
+# but otherwise it does not matter much
+Style/FormatStringToken:
+  Enabled: false

--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 13 08:20:34 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Changed placeholders in translatable strings (%<> -> %{})
+  to better support gettext language format tags (bsc#1171555)
+- 1.3.1
+
+-------------------------------------------------------------------
 Wed Jan 15 14:50:09 UTC 2020 - Ivan Kapelyukhin <ikapelyukhin@suse.com>
 
 - Version 1.3.0

--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rmt
-Version:        1.3.0
+Version:        1.3.1
 Release:        0
 BuildArch:      noarch
 

--- a/spec/rmt/ssl/certificate_generator_spec.rb
+++ b/spec/rmt/ssl/certificate_generator_spec.rb
@@ -322,7 +322,7 @@ describe RMT::SSL::CertificateGenerator do
 
     it 'raises and exception when write failed' do
       expect(Yast::SCR).to receive(:Write).with(Yast.path('.target.string'), filename, content).and_return(false)
-      expect { generator.send(:write_file, filename, content) }.to raise_error(RMT::SSL::Exception, "Failed to write file #{filename}")
+      expect { generator.send(:write_file, filename, content) }.to raise_error(RMT::SSL::Exception, "Error writing file '#{filename}'")
     end
   end
 end

--- a/src/lib/rmt/execute.rb
+++ b/src/lib/rmt/execute.rb
@@ -51,7 +51,7 @@ class RMT::Execute
   rescue Cheetah::ExecutionFailed => e
     Yast.import 'Report'
     Yast::Report.Error(
-      _("Execution of command \"%<command>s\" failed.\nExit code: %<exitcode>s\nError output: %<stderr>s") % {
+      _("Execution of command \"%{command}\" failed.\nExit code: %{exitcode}\nError output: %{stderr}") % {
         command:  e.commands.inspect,
         exitcode: e.status.exitstatus,
         stderr:   e.stderr

--- a/src/lib/rmt/shared/set_password_dialog.rb
+++ b/src/lib/rmt/shared/set_password_dialog.rb
@@ -44,7 +44,7 @@ class RMT::Shared::SetPasswordDialog < UI::Dialog
       return
     elsif password.size < @min_password_size
       Yast::UI.SetFocus(Id(:password))
-      Yast::Report.Error(_('Password has to have at least %<size>s characters.') % { size: @min_password_size })
+      Yast::Report.Error(_('Password has to have at least %{size} characters.') % { size: @min_password_size })
       return
     elsif password != password_confirmation
       Yast::UI.SetFocus(Id(:password_confirmation))

--- a/src/lib/rmt/ssl/certificate_generator.rb
+++ b/src/lib/rmt/ssl/certificate_generator.rb
@@ -146,7 +146,7 @@ class RMT::SSL::CertificateGenerator
   rescue Cheetah::ExecutionFailed, RMT::SSL::Exception => e
     Yast.import 'Report'
     Yast::Report.Error(
-      _("An error occurred during SSL certificate generation:\n%<error>s\n") % {
+      _("An error occurred during SSL certificate generation:\n%{error}\n") % {
         error: (e.class == Cheetah::ExecutionFailed) ? e.stderr : e.to_s
       }
     )
@@ -164,7 +164,9 @@ class RMT::SSL::CertificateGenerator
   end
 
   def write_file(filename, content)
-    result = Yast::SCR.Write(Yast.path('.target.string'), filename, content)
-    raise RMT::SSL::Exception, _('Failed to write file %<filename>s' % { filename: filename }) unless result
+    return if Yast::SCR.Write(Yast.path('.target.string'), filename, content)
+
+    Yast.import 'Message'
+    raise RMT::SSL::Exception, Yast::Message.ErrorWritingFile(filename)
   end
 end


### PR DESCRIPTION
- Related to https://github.com/yast/yast-devtools/pull/152
- There is no language format support in GNU Gettext for the `%<>` variant use `%{}` instead
- Use [`Message.ErrorWritingFile`](https://github.com/yast/yast-yast2/blob/66bc64d08c6ff017b88e3cff63fd02d78bbcf7f1/library/general/src/modules/Message.rb#L107)