### PR TITLE
build: do not build as noarch, as not all deps are arch-independent

### DIFF
--- a/package/yast2-rmt-rpmlintrc
+++ b/package/yast2-rmt-rpmlintrc
@@ -1,0 +1,2 @@
+addFilter("E: no-binary");
+

--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Thu Jun  9 10:47:13 UTC 2022 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Sync ExcludeArch with rmt-server: whenever rmt-server is not
+  available, the yast2-rmt module can't be usable neither.
+- No longer build as noarch: as the package is not installable on
+  all architectures, it is by definition not 'architecture
+  independent'.
+- Add rpmlintrc, filtering out "E: no-binary": the package is
+  intentionally not marked noarch.
+- 1.3.4
+
+-------------------------------------------------------------------
+
 Wed Apr  7 06:57:41 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapted unit test to recent changes in Yast::Report (related to

--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -17,12 +17,12 @@
 
 
 Name:           yast2-rmt
-Version:        1.3.3
+Version:        1.3.4
 Release:        0
-BuildArch:      noarch
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
+Source99:       %{name}-rpmlintrc
 
 Requires:       rmt-server >= 2.5.0
 Requires:       yast2
@@ -41,6 +41,8 @@ Summary:        YaST2 - Module to configure RMT
 License:        GPL-2.0-only
 Group:          System/YaST
 Url:            https://github.com/yast/yast-rmt
+# ExcludeArch synced with our main dependency: rmt-server
+ExcludeArch:    %{ix86} s390
 
 %description
 Provides the YaST module to configure the Repository Mirroring Tool (RMT) Server.


### PR DESCRIPTION
## Problem

* Package is built 'noarch', but is not installable on all architectures due to missing deps

## Solution

Build package arch dependent, despite not having binaries of its own


