### PR TITLE
Catch scc request timeout exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,35 @@ There different ways to run the module:
 * `DISPLAY= rake run` — forces to run in ncurses mode;
 * `Y2DIR=src/ /usr/sbin/yast2 --ncurses rmt` — same as above.
 
+#### Docker Setup
+
+To run the module within a Docker container:
+
+1. Select a proper Docker container image for YaST from https://registry.opensuse.org, according to the branch, e.g.:
+
+   * On branch `master`, use `yast/head/containers_tumbleweed/yast-ruby`.
+   * On branch `SLE-15-SP6`, use `yast/sle-15/sp6/containers/yast-ruby`.
+
+2. Run the Docker container with access to the localhost network with the chosen distribution and version:
+
+   ```shell
+   docker run --network host -v "$(pwd):/usr/src/app" -w "/usr/src/app" -it registry.opensuse.org/yast/sle-15/sp6/containers/yast-ruby sh
+   ```
+
+3. On the container, install the `rmt-server` package:
+
+   ```shell
+   zypper --non-interactive install rmt-server
+   ```
+
+4. Run the YaST RMT module with `rake run` or through the other ways previously described.
+
 ### Running tests
 
 It is possible to run the specs in a Docker container:
 
-```
-docker build -t yast-rmt-image .
-docker run -it yast-rmt-image rspec
+```shell
+docker run -v "$(pwd):/usr/src/app" -w "/usr/src/app" -it registry.opensuse.org/yast/sle-15/sp6/containers/yast-ruby rake test:unit
 ```
 
 ### Resources

--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Feb  8 16:10:29 UTC 2024 - Luis Caparroz <luis.caparroz@suse.com>
+
+- Adds UI dialog to allow the user to retry the SCC credential validation when
+  the request times out (bsc#1218084).
+- Adds HTTP User-Agent to requests to the SCC API and changes the enpoint for
+  credential validation.
+- Version 1.3.5
+
+-------------------------------------------------------------------
 Thu Jun  9 10:47:13 UTC 2022 - Dominique Leuenberger <dimstar@opensuse.org>
 
 - Sync ExcludeArch with rmt-server: whenever rmt-server is not

--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rmt
-Version:        1.3.4
+Version:        1.3.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

When the SCC API times out during credentials validation, the module would break with an "Internal error" message displaying details about the Ruby exception.

- *Bugzilla link*: https://bugzilla.suse.com/show_bug.cgi?id=1218084

## Solution

Proper exception treatment was implemented, and now, a UI popup is displayed to the user, giving them the choice to either retry the validation or cancel the operation.

## Testing

- *Added a new unit test*: `spec/rmt/wizard_scc_page_spec.rb`.
- *Tested manually*: the new behavior was tested according to the update [`README` instructions for a Docker setup](https://github.com/yast/yast-rmt/blob/04dd0fb118fa3e0f382affbbbce29ab827de2b08/README.md#docker-setup), running the module against a localhost server to simulate a timeout.

## Screenshots

### 1. [Existing] Initial screen when running `yast2 rmt`

![image](https://github.com/yast/yast-rmt/assets/8546650/ec22542f-a6f5-42fc-8547-0ffa8078f821)

### 2. [Existing] Screen after pressing `Next` to verify SCC Credentials and the request is taking too long to complete

![image](https://github.com/yast/yast-rmt/assets/8546650/5c7e71c5-085b-430c-b843-164f977b1b7d)

### 3. [New] Popup dialog shown to the user when the request times out

The new UI was added on this step. This is the only change to UI.

![image](https://github.com/yast/yast-rmt/assets/8546650/a69890a2-374b-42a9-9786-b128c98d1374)

### 4. [Existing] Screen if the user chooses to cancel the operation

![image](https://github.com/yast/yast-rmt/assets/8546650/d173ba9a-7a04-402b-93e0-0d2b680a82a8)
