### PR TITLE
Fix unstranlated strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v2
 
+      - name: Install ruby-devel package
+        run: zypper --non-interactive install ruby-devel
+
       - name: Install project dependencies
         run: bundle install
 

--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar  3 11:52:35 UTC 2025 - Luis Caparroz <luis.caparroz@suse.com>
+
+- Mark strings on UI dialogs for tranlation (bsc#1127676).
+- Version 1.3.6
+
+-------------------------------------------------------------------
 Thu Feb  8 16:10:29 UTC 2024 - Luis Caparroz <luis.caparroz@suse.com>
 
 - Adds UI dialog to allow the user to retry the SCC credential validation when

--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rmt
-Version:        1.3.5
+Version:        1.3.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/rmt.rb
+++ b/src/lib/rmt.rb
@@ -17,5 +17,5 @@
 #  you may find current contact information at www.suse.com
 
 module RMT
-  VERSION = '1.3.5'.freeze
+  VERSION = '1.3.6'.freeze
 end

--- a/src/lib/rmt/maria_db/current_root_password_dialog.rb
+++ b/src/lib/rmt/maria_db/current_root_password_dialog.rb
@@ -25,11 +25,12 @@ module RMT::MariaDB; end
 
 class RMT::MariaDB::CurrentRootPasswordDialog < RMT::Shared::InputPasswordDialog
   def initialize
+    textdomain 'rmt'
     super
 
-    @dialog_heading = N_('Database root password is required')
-    @dialog_label = N_('In order to setup RMT, database access is required. Please provide the current database root password.')
-    @password_field_label = N_('MariaDB root &password')
+    @dialog_heading = _('Database root password is required')
+    @dialog_label = _('In order to setup RMT, database access is required. Please provide the current database root password.')
+    @password_field_label = _('MariaDB root &password')
   end
 
   private

--- a/src/lib/rmt/maria_db/new_root_password_dialog.rb
+++ b/src/lib/rmt/maria_db/new_root_password_dialog.rb
@@ -25,11 +25,12 @@ module RMT::MariaDB; end
 
 class RMT::MariaDB::NewRootPasswordDialog < RMT::Shared::SetPasswordDialog
   def initialize
+    textdomain 'rmt'
     super
 
-    @dialog_heading = N_('Setting database root password')
-    @dialog_label = N_('The current MariaDB root password is empty. Setting a root password is required for security reasons.')
-    @password_field_label = N_('New MariaDB root &Password')
+    @dialog_heading = _('Setting database root password')
+    @dialog_label = _('The current MariaDB root password is empty. Setting a root password is required for security reasons.')
+    @password_field_label = _('New MariaDB root &Password')
   end
 
   def set_root_password(new_root_password, hostname)

--- a/src/lib/rmt/shared/input_password_dialog.rb
+++ b/src/lib/rmt/shared/input_password_dialog.rb
@@ -53,14 +53,14 @@ class RMT::Shared::InputPasswordDialog < UI::Dialog
   def dialog_content
     VBox(
       VSpacing(1),
-      Heading(_(@dialog_heading)),
+      Heading(@dialog_heading),
       VSpacing(1),
       HBox(
         HSpacing(2),
         VBox(
-          Label(_(@dialog_label)),
+          Label(@dialog_label),
           VSpacing(1),
-          MinWidth(15, Password(Id(:password), _(@password_field_label)))
+          MinWidth(15, Password(Id(:password), @password_field_label))
         ),
         HSpacing(2)
       ),

--- a/src/lib/rmt/shared/set_password_dialog.rb
+++ b/src/lib/rmt/shared/set_password_dialog.rb
@@ -25,7 +25,7 @@ module RMT::Shared; end
 class RMT::Shared::SetPasswordDialog < UI::Dialog
   def initialize
     @min_password_size = 0
-    @password_confirmation_field_label = N_('C&onfirm Password')
+    @password_confirmation_field_label = _('C&onfirm Password')
     textdomain 'rmt'
   end
 
@@ -60,19 +60,15 @@ class RMT::Shared::SetPasswordDialog < UI::Dialog
   def dialog_content
     VBox(
       VSpacing(1),
-      Heading(_(@dialog_heading)),
+      Heading(@dialog_heading),
       VSpacing(1),
       HBox(
         HSpacing(2),
         VBox(
-          Label(
-            _(
-              @dialog_label
-            )
-          ),
+          Label(@dialog_label),
           VSpacing(1),
-          MinWidth(15, Password(Id(:password), _(@password_field_label))),
-          MinWidth(15, Password(Id(:password_confirmation), _(@password_confirmation_field_label)))
+          MinWidth(15, Password(Id(:password), @password_field_label)),
+          MinWidth(15, Password(Id(:password_confirmation), @password_confirmation_field_label))
         ),
         HSpacing(2)
       ),

--- a/src/lib/rmt/ssl/current_ca_password_dialog.rb
+++ b/src/lib/rmt/ssl/current_ca_password_dialog.rb
@@ -26,11 +26,12 @@ module RMT::SSL; end
 
 class RMT::SSL::CurrentCaPasswordDialog < RMT::Shared::InputPasswordDialog
   def initialize
+    textdomain 'rmt'
     super
 
-    @dialog_heading = N_('Your CA private key is encrypted.')
-    @dialog_label = N_('Please input password.')
-    @password_field_label = N_('&Password')
+    @dialog_heading = _('Your CA private key is encrypted.')
+    @dialog_label = _('Please input password.')
+    @password_field_label = _('&Password')
     @cert_generator = RMT::SSL::CertificateGenerator.new
   end
 

--- a/src/lib/rmt/ssl/new_ca_password_dialog.rb
+++ b/src/lib/rmt/ssl/new_ca_password_dialog.rb
@@ -25,11 +25,12 @@ module RMT::SSL; end
 
 class RMT::SSL::NewCaPasswordDialog < RMT::Shared::SetPasswordDialog
   def initialize
+    textdomain 'rmt'
     super
 
-    @dialog_heading = N_('Setting CA private key password')
-    @dialog_label = N_('Please set a password for the CA private key.')
-    @password_field_label = N_('&Password')
+    @dialog_heading = _('Setting CA private key password')
+    @dialog_label = _('Please set a password for the CA private key.')
+    @password_field_label = _('&Password')
     @min_password_size = 4
   end
 end


### PR DESCRIPTION
## Problem

Some strings in the UI dialogs are not translated, resulting in text being shown partially in the configured locale language, partially in English.

The issue was originally reported for the Simplified Chinese language, but it can also be replicated for Brazilian Portuguese, leading to infer that probably all translations are affected by the same issue.

### Cause

The strings not being translated are marked with the [function `N_(...)`](https://github.com/ruby-gettext/gettext?tab=readme-ov-file#n_-and-nn_-makes-dynamic-translation-messages-readable-for-the-gettext-parser), assigned to instance variables that would later be localized with the function `_(...)`, which is quite common when using the [`gettext` Ruby gem](https://github.com/ruby-gettext/gettext).

However, the cause is that the `y2tools y2makepot` command, used to identify localized strings, doesn't consider the function `N_(...)` when scanning the files ([source code](https://github.com/yast/yast-devtools/blob/master/build-tools/scripts/gettextdomains#L66)). 

- *Bugzilla link*: https://bugzilla.suse.com/show_bug.cgi?id=1127676
- *openQA link*: https://openqa.suse.de/tests/15854944

## Solution

We changed the code to no longer use the function `N_(...)`, only `_(...)`, and adapted the classes that relied on receiving strings with `N_(...)` through instance variables.

## Testing

- *No new unit tests were added*: it's only a change to how string localization is handled.
- It will only be possible to test the effects of this change after a new translation round:
    - Submitting new strings for translation ([i18n](https://l10n.opensuse.org/projects/yast-rmt/)).
    - Asking for the translation of those strings.
    - Bundling the new translations in the `yast2-rmt` package.

Meanwhile, you can verify that files previously not considered for translation are caught by the command `rake check:pot`:

- `src/lib/rmt/maria_db/current_root_password_dialog.rb`
- `src/lib/rmt/maria_db/new_root_password_dialog.rb`
- `src/lib/rmt/ssl/current_ca_password_dialog.rb`
- `src/lib/rmt/ssl/new_ca_password_dialog.rb`

Output example from running `rake check:pot`:

```shell
$ rake check:pot
/usr/bin/y2tool y2makepot
Creating ./rmt.pot from  ./src/lib/rmt/execute.rb ./src/lib/rmt/maria_db/current_root_password_dialog.rb ./src/lib/rmt/maria_db/new_root_password_dialog.rb ./src/lib/rmt/shared/input_password_dialog.rb ./src/lib/rmt/shared/set_password_dialog.rb ./src/lib/rmt/ssl/alternative_common_name_dialog.rb ./src/lib/rmt/ssl/certificate_generator.rb ./src/lib/rmt/ssl/current_ca_password_dialog.rb ./src/lib/rmt/ssl/new_ca_password_dialog.rb ./src/lib/rmt/utils.rb ./src/lib/rmt/wizard_final_page.rb ./src/lib/rmt/wizard_firewall_page.rb ./src/lib/rmt/wizard_maria_db_page.rb ./src/lib/rmt/wizard_rmt_service_page.rb ./src/lib/rmt/wizard_scc_page.rb ./src/lib/rmt/wizard_ssl_page.rb ...
rmt.pot: 3 format flags added
Verifying rmt.pot validity...
rmt.pot:8: warning: header field 'Project-Id-Version' still has the initial default value
rmt.pot:8: warning: header field 'Last-Translator' still has the initial default value
rmt.pot:8: warning: header field 'Language-Team' still has the initial default value
rmt.pot:8: warning: header field 'Language' still has the initial default value
...OK
Checking rmt.pot...
```

You can also read the generated `rmt.pot` file and verify that the strings previously marked with `N_(...)` (see the "Files changed" tab) are present there, e.g.:

```pot
#: src/lib/rmt/maria_db/current_root_password_dialog.rb:31
msgid "Database root password is required"
msgstr ""

#: src/lib/rmt/maria_db/current_root_password_dialog.rb:32
msgid ""
"In order to setup RMT, database access is required. Please provide the current"
" database root password."
msgstr ""

#: src/lib/rmt/maria_db/current_root_password_dialog.rb:33
msgid "MariaDB root &password"
msgstr ""
```

## Screenshots

N/A.