### PR TITLE
Fix: Use FIPS compatible cert key generation algorithms

### DIFF
--- a/spec/rmt/ssl/certificate_generator_spec.rb
+++ b/spec/rmt/ssl/certificate_generator_spec.rb
@@ -160,8 +160,7 @@ describe RMT::SSL::CertificateGenerator do
 
         expect_any_instance_of(Cheetah::DefaultRecorder).not_to receive(:record_stdin)
         expect(RMT::Execute).to receive(:on_target!).with(
-          'openssl', 'genrsa', '-aes256', '-passout', 'stdin', '-out',
-          ssl_files[:ca_private_key], described_class::OPENSSL_KEY_BITS,
+          'openssl', 'genpkey', '-algorithm RSA', '-aes256 -out', ssl_files[:ca_private_key] , '-pkeyopt rsa_keygen_bits:', described_class::OPENSSL_KEY_BITS,
           stdin: ca_password,
           logger: nil
         )

--- a/spec/rmt/ssl/certificate_generator_spec.rb
+++ b/spec/rmt/ssl/certificate_generator_spec.rb
@@ -160,7 +160,7 @@ describe RMT::SSL::CertificateGenerator do
 
         expect_any_instance_of(Cheetah::DefaultRecorder).not_to receive(:record_stdin)
         expect(RMT::Execute).to receive(:on_target!).with(
-          'openssl', 'genpkey', '-algorithm RSA', '-aes256 -out', ssl_files[:ca_private_key] , '-pkeyopt rsa_keygen_bits:', described_class::OPENSSL_KEY_BITS,
+          'openssl', 'genpkey', '-algorithm RSA', '-aes256 -out', ssl_files[:ca_private_key], '-pkeyopt rsa_keygen_bits:', described_class::OPENSSL_KEY_BITS,
           stdin: ca_password,
           logger: nil
         )

--- a/src/lib/rmt/ssl/certificate_generator.rb
+++ b/src/lib/rmt/ssl/certificate_generator.rb
@@ -98,7 +98,7 @@ class RMT::SSL::CertificateGenerator
       Yast::SCR.Write(Yast.path('.target.string'), @ssl_paths[:ca_config], config_generator.make_ca_config)
 
       RMT::Execute.on_target!(
-        'openssl', 'genrsa', '-aes256', '-passout', 'stdin', '-out', @ssl_paths[:ca_private_key], OPENSSL_KEY_BITS,
+        'openssl', 'genpkey', '-algorithm RSA', '-aes256 -out', @ssl_paths[:ca_private_key] , '-pkeyopt rsa_keygen_bits:', OPENSSL_KEY_BITS,
         stdin: ca_password,
         logger: nil # do not log in order to securely pass password
       )

--- a/src/lib/rmt/ssl/certificate_generator.rb
+++ b/src/lib/rmt/ssl/certificate_generator.rb
@@ -98,7 +98,7 @@ class RMT::SSL::CertificateGenerator
       Yast::SCR.Write(Yast.path('.target.string'), @ssl_paths[:ca_config], config_generator.make_ca_config)
 
       RMT::Execute.on_target!(
-        'openssl', 'genpkey', '-algorithm RSA', '-aes256 -out', @ssl_paths[:ca_private_key] , '-pkeyopt rsa_keygen_bits:', OPENSSL_KEY_BITS,
+        'openssl', 'genpkey', '-algorithm RSA', '-aes256 -out', @ssl_paths[:ca_private_key], '-pkeyopt rsa_keygen_bits:', OPENSSL_KEY_BITS,
         stdin: ca_password,
         logger: nil # do not log in order to securely pass password
       )


### PR DESCRIPTION
## Problem

yast-rmt fails in certificate generation step when using fips mode. This is due to use of unsanctioned algorithms.

- https://bugzilla.suse.com/show_bug.cgi?id=1235462

## Solution

We use fips compatible encryption algorithm. The old approach used MD5 for password encryption which is not included in the FIPS standard.

To generate an encrypted private key in a FIPS-compatible way, use the PKCS#8 format with PBES2 encryption.


## Testing

To test, run:

`Y2DIR=./ sudo /usr/sbin/yast2 rmt`


## Screenshots

*If the fix affects the UI attach some screenshots here.*

