### PR TITLE
Remove system forwarding optin

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Mon Sep  1 10:06:04 UTC 2025 - Natnael Getahun <natnael.getahun@suse.com>
 
-- Ensure compatibility with FIPS mode (bsc#1235462)
 - Version 1.3.7 
+- Ensure compatibility with FIPS mode (bsc#1235462)
+- Remove 'Forward systems to SCC' checkbox (scc-262)
 
 -------------------------------------------------------------------
 Mon Mar  3 11:52:35 UTC 2025 - Luis Caparroz <luis.caparroz@suse.com>

--- a/spec/rmt/wizard_scc_page_spec.rb
+++ b/spec/rmt/wizard_scc_page_spec.rb
@@ -23,7 +23,7 @@ Yast.import 'Wizard'
 describe RMT::WizardSCCPage do
   subject(:scc_page) { described_class.new(config) }
 
-  let(:config) { { 'scc' => { 'username' => 'user_mcuserface', 'password' => 'test', 'sync_systems' => true } } }
+  let(:config) { { 'scc' => { 'username' => 'user_mcuserface', 'password' => 'test', 'sync_systems' => false } } }
 
   describe '#render_content' do
     it 'renders UI elements' do
@@ -34,7 +34,6 @@ describe RMT::WizardSCCPage do
 
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:scc_username), :Value, config['scc']['username'])
       expect(Yast::UI).to receive(:ChangeWidget).with(Id(:scc_password), :Value, config['scc']['password'])
-      expect(Yast::UI).to receive(:ChangeWidget).with(Id(:scc_sync_systems), :Value, config['scc']['sync_systems'])
 
       scc_page.render_content
     end
@@ -80,7 +79,6 @@ describe RMT::WizardSCCPage do
     before do
       expect(Yast::UI).to receive(:QueryWidget).with(Id(:scc_username), :Value)
       expect(Yast::UI).to receive(:QueryWidget).with(Id(:scc_password), :Value)
-      expect(Yast::UI).to receive(:QueryWidget).with(Id(:scc_sync_systems), :Value)
     end
 
     context "when SCC credentials aren't valid and the error is not ignored" do

--- a/spec/rmt/wizard_scc_page_spec.rb
+++ b/spec/rmt/wizard_scc_page_spec.rb
@@ -23,7 +23,7 @@ Yast.import 'Wizard'
 describe RMT::WizardSCCPage do
   subject(:scc_page) { described_class.new(config) }
 
-  let(:config) { { 'scc' => { 'username' => 'user_mcuserface', 'password' => 'test', 'sync_systems' => false } } }
+  let(:config) { { 'scc' => { 'username' => 'user_mcuserface', 'password' => 'test', 'sync_systems' => true } } }
 
   describe '#render_content' do
     it 'renders UI elements' do

--- a/src/lib/rmt/ssl/config_generator.rb
+++ b/src/lib/rmt/ssl/config_generator.rb
@@ -49,6 +49,6 @@ class RMT::SSL::ConfigGenerator
 
   def make_server_config
     template = File.read(File.join(@templates_dir, 'rmt-server-cert.cnf.erb'))
-    ERB.new(template, nil, '<>').result(binding)
+    ERB.new(template, trim_mode: '<>').result(binding)
   end
 end

--- a/src/lib/rmt/wizard_scc_page.rb
+++ b/src/lib/rmt/wizard_scc_page.rb
@@ -52,8 +52,6 @@ class RMT::WizardSCCPage < Yast::Client
           HSquash(
             MinWidth(30, Password(Id(:scc_password), _('Organization &Password')))
           ),
-          VSpacing(1),
-          CheckBox(Id(:scc_sync_systems), _('Forward systems to SCC')),
           VSpacing(1)
         ),
         HSpacing(1)
@@ -70,7 +68,6 @@ class RMT::WizardSCCPage < Yast::Client
 
     UI.ChangeWidget(Id(:scc_username), :Value, @config['scc']['username'])
     UI.ChangeWidget(Id(:scc_password), :Value, @config['scc']['password'])
-    UI.ChangeWidget(Id(:scc_sync_systems), :Value, @config['scc']['sync_systems'])
   end
 
   def abort_handler
@@ -80,7 +77,7 @@ class RMT::WizardSCCPage < Yast::Client
   def skip_handler
     @config['scc']['username'] = UI.QueryWidget(Id(:scc_username), :Value)
     @config['scc']['password'] = UI.QueryWidget(Id(:scc_password), :Value)
-    @config['scc']['sync_systems'] = UI.QueryWidget(Id(:scc_sync_systems), :Value)
+    @config['scc']['sync_systems'] = false
 
     return unless Popup.AnyQuestion(
       _('Skip SCC registration?'),
@@ -97,7 +94,7 @@ class RMT::WizardSCCPage < Yast::Client
   def next_handler
     @config['scc']['username'] = UI.QueryWidget(Id(:scc_username), :Value)
     @config['scc']['password'] = UI.QueryWidget(Id(:scc_password), :Value)
-    @config['scc']['sync_systems'] = UI.QueryWidget(Id(:scc_sync_systems), :Value)
+    @config['scc']['sync_systems'] = false
 
     return unless scc_credentials_valid? || Popup.AnyQuestion(
       _('Continue with invalid credentials?'),

--- a/src/lib/rmt/wizard_scc_page.rb
+++ b/src/lib/rmt/wizard_scc_page.rb
@@ -77,7 +77,7 @@ class RMT::WizardSCCPage < Yast::Client
   def skip_handler
     @config['scc']['username'] = UI.QueryWidget(Id(:scc_username), :Value)
     @config['scc']['password'] = UI.QueryWidget(Id(:scc_password), :Value)
-    @config['scc']['sync_systems'] = false
+    @config['scc']['sync_systems'] = true
 
     return unless Popup.AnyQuestion(
       _('Skip SCC registration?'),
@@ -94,7 +94,7 @@ class RMT::WizardSCCPage < Yast::Client
   def next_handler
     @config['scc']['username'] = UI.QueryWidget(Id(:scc_username), :Value)
     @config['scc']['password'] = UI.QueryWidget(Id(:scc_password), :Value)
-    @config['scc']['sync_systems'] = false
+    @config['scc']['sync_systems'] = true
 
     return unless scc_credentials_valid? || Popup.AnyQuestion(
       _('Continue with invalid credentials?'),


### PR DESCRIPTION
This PR removes the check box for system scc sync configuration.

## Testing
- `bundle exec rake run`, you should not see a checkbox when adding scc credenetial

## Screenshots

<img width="1366" height="833" alt="image" src="https://github.com/user-attachments/assets/ee1a3d65-c9e1-46b0-9385-4aa63ad03526" />


