### PR TITLE
Revert 1.3.8 version bump

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,10 +1,4 @@
 -------------------------------------------------------------------
-Tue Mar 10 09:00:28 UTC 2026 - Michal Filka <mfilka@suse.com>
-
-- jsc#PED-14507
-  - Removed reference to update-desktop-files from spec file 
-  - 1.3.8
--------------------------------------------------------------------
 Mon Sep  1 10:06:04 UTC 2025 - Natnael Getahun <natnael.getahun@suse.com>
 
 - Version 1.3.7 

--- a/package/yast2-rmt.spec
+++ b/package/yast2-rmt.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-rmt
-Version:        1.3.8
+Version:        1.3.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -28,6 +28,7 @@ Requires:       rmt-server >= 2.5.0
 Requires:       yast2
 Requires:       yast2-ruby-bindings
 
+BuildRequires:  update-desktop-files
 BuildRequires:  yast2
 BuildRequires:  yast2-devtools
 BuildRequires:  yast2-ruby-bindings


### PR DESCRIPTION
Reverting direct pushes that bumped the version to 1.3.8. This is necessary to correctly release 1.3.7 with the required fixes.