### PR TITLE
Fix ERB initialization for older Ruby versions

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,9 +1,10 @@
 -------------------------------------------------------------------
 Mon Sep  1 10:06:04 UTC 2025 - Natnael Getahun <natnael.getahun@suse.com>
 
-- Version 1.3.7 
 - Ensure compatibility with FIPS mode (bsc#1235462)
 - Remove 'Forward systems to SCC' checkbox (scc-262)
+- Fix ERB initialization for older Ruby versions (bsc#1146403)
+- Version 1.3.7 
 
 -------------------------------------------------------------------
 Mon Mar  3 11:52:35 UTC 2025 - Luis Caparroz <luis.caparroz@suse.com>

--- a/src/lib/rmt/ssl/config_generator.rb
+++ b/src/lib/rmt/ssl/config_generator.rb
@@ -49,6 +49,10 @@ class RMT::SSL::ConfigGenerator
 
   def make_server_config
     template = File.read(File.join(@templates_dir, 'rmt-server-cert.cnf.erb'))
-    ERB.new(template, trim_mode: '<>').result(binding)
+    if RUBY_VERSION >= '2.6'
+      ERB.new(template, trim_mode: '<>').result(binding)
+    else
+      ERB.new(template, nil, '<>').result(binding)
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a build failure on older Ruby versions (like SLE 15 SP3/SP4) where ERB.new expects different arguments. It also includes the changelog update for the 1.3.7 release, ensuring it matches what is currently on OBS.