### PR TITLE
Fix OpenSSL genpkey parameter formatting for SSL certificate generation

### DIFF
--- a/package/yast2-rmt.changes
+++ b/package/yast2-rmt.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Mon Sep  1 10:06:04 UTC 2025 - Natnael Getahun <natnael.getahun@suse.com>
 
+- Fix OpenSSL genpkey parameter formatting for SSL certificate generation (bsc#1266671)
 - Ensure compatibility with FIPS mode (bsc#1235462)
 - Remove 'Forward systems to SCC' checkbox (scc-262)
 - Fix ERB initialization for older Ruby versions (bsc#1146403)

--- a/spec/rmt/ssl/certificate_generator_spec.rb
+++ b/spec/rmt/ssl/certificate_generator_spec.rb
@@ -161,7 +161,7 @@ describe RMT::SSL::CertificateGenerator do
         expect_any_instance_of(Cheetah::DefaultRecorder).not_to receive(:record_stdin)
         expect(RMT::Execute).to receive(:on_target!).with(
           'openssl', 'genpkey', '-algorithm', 'RSA', '-pass', 'stdin', '-aes256',
-          '-out', ssl_files[:ca_private_key], '-pkeyopt', "rsa_keygen_bits: #{described_class::OPENSSL_KEY_BITS}",
+          '-out', ssl_files[:ca_private_key], '-pkeyopt', "rsa_keygen_bits:#{described_class::OPENSSL_KEY_BITS}",
           stdin: ca_password,
           logger: nil
         )

--- a/src/lib/rmt/ssl/certificate_generator.rb
+++ b/src/lib/rmt/ssl/certificate_generator.rb
@@ -99,7 +99,7 @@ class RMT::SSL::CertificateGenerator
 
       RMT::Execute.on_target!(
         'openssl', 'genpkey', '-algorithm', 'RSA', '-pass', 'stdin', '-aes256',
-        '-out', @ssl_paths[:ca_private_key], '-pkeyopt', "rsa_keygen_bits: #{OPENSSL_KEY_BITS}",
+        '-out', @ssl_paths[:ca_private_key], '-pkeyopt', "rsa_keygen_bits:#{OPENSSL_KEY_BITS}",
         stdin: ca_password,
         logger: nil # do not log in order to securely pass password
       )


### PR DESCRIPTION
## Summary
Fixes the OpenSSL genpkey command parameter formatting that was causing SSL certificate generation to fail during the RMT wizard setup.

## Problem
The OpenQA test reported the following error:
```
Error setting rsa_keygen_bits: 2048 parameter
```

This was caused by incorrect parameter formatting in the `-pkeyopt` argument. The parameter `rsa_keygen_bits: 2048` had a space after the colon, but OpenSSL expects `rsa_keygen_bits:2048` (no space).

## Root Cause
This issue was introduced in commit 0b73535 when migrating from `genrsa` to `genpkey` for FIPS compatibility (bsc#1235462).

## Changes
- Fixed the `-pkeyopt` parameter in `certificate_generator.rb` (removed space after colon)
- Updated the corresponding test expectation in `certificate_generator_spec.rb`
- Added changelog entry referencing bsc#1266671

## Testing
Verified the fix with OpenSSL command line:
```bash
# Correct syntax (no space) - works ✓
openssl genpkey -algorithm RSA -pass stdin -aes256 \
  -out /tmp/test.key -pkeyopt rsa_keygen_bits:2048

# Incorrect syntax (with space) - fails ✗
openssl genpkey -algorithm RSA -pkeyopt "rsa_keygen_bits: 2048" \
  -out /tmp/test.key
# Error: genpkey: Error setting rsa_keygen_bits: 2048 parameter
```

## References
- Fixes: bsc#1266671
- Related: bsc#1235462 (FIPS compatibility)
- OpenQA failure: https://openqa.suse.de/tests/22540520#step/rmt_feature/20